### PR TITLE
[FEATURE]: add path alias for lib folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ Inside `src`, we have a demo app for use during development and testing. When ad
 
 After that, you can run `yarn dev` and visit the demo app at `localhost:3000`. You should see a link to your component on the home page.
 
+**Note:** When importing components and hooks into demo pages, you can use a path alias (`@lib/components` or `@lib/hooks`) to avoid figuring out the levels of relative paths.
+
 ## Testing
 
 We use `cypress` for both e2e and unit (component) tests -- make sure to place the test inside the appropriate sub-directory in the `cypress/` directory: e2e tests in `cypress/e2e` and unit tests in `cypress/component`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link, useLocation, useRoutes } from 'react-router-dom';
 import TestDemo from './demos/TestDemo';
 import NextTest from './demos/NextTest';

--- a/src/demos/NextTest.tsx
+++ b/src/demos/NextTest.tsx
@@ -1,4 +1,4 @@
-import { TestComponent } from '../../lib/components';
+import { TestComponent } from '@lib/components';
 
 const NextTest = () => {
   return <TestComponent foo={'bar'} />;

--- a/src/demos/TestDemo.tsx
+++ b/src/demos/TestDemo.tsx
@@ -1,4 +1,4 @@
-import { useTestHook } from '../../lib/hooks';
+import { useTestHook } from '@lib/hooks';
 
 const MockComponent: React.FC = () => {
   const testHookAcceptedValue = 'bar';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@lib/*": ["./lib/*"],
+    }
   },
   "include": ["lib", "src", "cypress"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,6 @@ import * as path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  esbuild: {
-    minify: false,
-  },
   plugins: [
     react(),
     dts({
@@ -22,6 +19,11 @@ export default defineConfig({
       cypress: true,
     }),
   ],
+  resolve: {
+    alias: {
+      '@lib': path.resolve(__dirname, './lib'),
+    }
+  },
   build: {
     sourcemap: true,
     lib: {


### PR DESCRIPTION
This PR implements using the `resolve.alias` feature of `vite` so we can import files from `@lib/components` or `@lib/hooks` instead of using relative paths (`../../../etc.ts`).